### PR TITLE
Date formatting problem

### DIFF
--- a/generators/authenticated/templates/spec/fixtures/users.yml
+++ b/generators/authenticated/templates/spec/fixtures/users.yml
@@ -17,7 +17,7 @@ quentin:
   salt:                      <%= salts[0]   %> # SHA1('0')
   crypted_password:          <%= passwds[0] %> # 'monkey'
   created_at:                <%%= 5.days.ago.to_s :db  %>
-  remember_token_expires_at: <%%= 1.days.from_now.to_s %>
+  remember_token_expires_at: <%%= 1.days.from_now.to_s :db %>
   remember_token:            <%= make_fake_token %>
 <% if options[:include_activation] -%>
   activation_code:           


### PR DESCRIPTION
Hey, feel free to pull this minor change that fixes errors when running rspec against a MySQL database that look like the following:

ActiveRecord::StatementInvalid in 'UsersController does not activate user with blank key'
Mysql::Error: Incorrect datetime value: '2010-12-05 04:11:14 -0600' for column 'remember_token_expires_at' at row 1:

-Shannon
