### PR TITLE
Make the README actually markdown

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -179,7 +179,7 @@ Pay attention, may be this is not an issue for everybody, but if you should have
 
  * With `--stateful`, add an observer to `config/environment.rb`:
 
-     config.active_record.observers = :user_observer
+       config.active_record.observers = :user_observer
 
 and modify the users resource line to read
 

--- a/README.markdown
+++ b/README.markdown
@@ -148,48 +148,43 @@ To use the generator:
 
 ## After installing
 
-The below assumes a Model named 'User' and a Controller named 'Session'; please
-alter to suit. There are additional security minutae in `notes/README-Tradeoffs`
--- only the paranoid or the curious need bother, though.
+The below assumes a Model named 'User' and a Controller named 'Session'; please alter to suit. There are additional security minutae in `notes/README-Tradeoffs` -- only the paranoid or the curious need bother, though.
 
-* Add these familiar login URLs to your `config/routes.rb` if you like:
+ * Add these familiar login URLs to your `config/routes.rb` if you like:
 
-    map.signup  '/signup', :controller => 'users',   :action => 'new'
-    map.login  '/login',  :controller => 'session', :action => 'new'
-    map.logout '/logout', :controller => 'session', :action => 'destroy'
+     map.signup  '/signup', :controller => 'users',   :action => 'new'
+     map.login  '/login',  :controller => 'session', :action => 'new'
+     map.logout '/logout', :controller => 'session', :action => 'destroy'
 
-* With `--include-activation`, also add to your `config/routes.rb`:
+ * With `--include-activation`, also add to your `config/routes.rb`:
 
-    map.activate '/activate/:activation_code', :controller => 'users', :action => 'activate', :activation_code => nil
+     map.activate '/activate/:activation_code', :controller => 'users', :action => 'activate', :activation_code => nil
 
   and add an observer to `config/environment.rb`:
 
-    config.active_record.observers = :user_observer
+     config.active_record.observers = :user_observer
 
-  Pay attention, may be this is not an issue for everybody, but if you should
-  have problems, that the sent activation_code does match with that in the
-  database stored, reload your user object before sending its data through email
-  something like:
+  Pay attention, may be this is not an issue for everybody, but if you should have problems, that the sent activation_code does match with that in the database stored, reload your user object before sending its data through email something like:
 
-    class UserObserver < ActiveRecord::Observer
-      def after_create(user)
-        user.reload
-        UserMailer.deliver_signup_notification(user)
-      end
-      def after_save(user)
-        user.reload
-        UserMailer.deliver_activation(user) if user.recently_activated?
-      end
-    end
+     class UserObserver < ActiveRecord::Observer
+       def after_create(user)
+         user.reload
+         UserMailer.deliver_signup_notification(user)
+       end
+       def after_save(user)
+         user.reload
+         UserMailer.deliver_activation(user) if user.recently_activated?
+       end
+     end
 
-* With `--stateful`, add an observer to config/environment.rb:
+ * With `--stateful`, add an observer to config/environment.rb:
 
-    config.active_record.observers = :user_observer
+     config.active_record.observers = :user_observer
 
   and modify the users resource line to read
 
-    map.resources :users, :member => { :suspend   => :put,
-                                       :unsuspend => :put,
-                                       :purge     => :delete }
+     map.resources :users, :member => { :suspend   => :put,
+                                        :unsuspend => :put,
+                                        :purge     => :delete }
 
 * If you use a public repository for your code (such as github, rubyforge, gitorious, etc.) make sure to NOT post your site_keys.rb (add a line like '/config/initializers/site_keys.rb' to your .gitignore or do the svn ignore dance), but make sure you DO keep it backed up somewhere safe.

--- a/README.markdown
+++ b/README.markdown
@@ -152,13 +152,13 @@ The below assumes a Model named 'User' and a Controller named 'Session'; please 
 
  * Add these familiar login URLs to your `config/routes.rb` if you like:
 
-    map.signup  '/signup', :controller => 'users',  :action => 'new'
-    map.login  '/login',  :controller => 'session', :action => 'new'
-    map.logout '/logout', :controller => 'session', :action => 'destroy'
+       map.signup  '/signup', :controller => 'users',  :action => 'new'
+       map.login  '/login',  :controller => 'session', :action => 'new'
+       map.logout '/logout', :controller => 'session', :action => 'destroy'
 
  * With `--include-activation`, also add to your `config/routes.rb`:
 
-    map.activate '/activate/:activation_code', :controller => 'users', :action => 'activate', :activation_code => nil
+       map.activate '/activate/:activation_code', :controller => 'users', :action => 'activate', :activation_code => nil
 
 and add an observer to `config/environment.rb`:
 
@@ -179,7 +179,7 @@ Pay attention, may be this is not an issue for everybody, but if you should have
 
  * With `--stateful`, add an observer to `config/environment.rb`:
 
-    config.active_record.observers = :user_observer
+     config.active_record.observers = :user_observer
 
 and modify the users resource line to read
 

--- a/README.markdown
+++ b/README.markdown
@@ -1,4 +1,4 @@
-# "Restful Authentication Generator"
+# Restful Authentication Generator
 
 This widely-used plugin provides a foundation for securely managing user authentication:
 
@@ -59,7 +59,7 @@ from there.
 
 ***************************************************************************
 
-<a id="AWESOME"/> </a>
+<div id="AWESOME"/></div>
 
 ## Exciting new features
 
@@ -101,7 +101,7 @@ By default, email and usernames are validated against a somewhat strict pattern;
 
 ***************************************************************************
 
-<a id="INSTALLATION"/> </a>
+<div id="INSTALLATION"/></div>
 
 ## Installation
 
@@ -144,7 +144,7 @@ To use the generator:
  * --skip-routes: Don't generate a resource line in `config/routes.rb`
 
 ***************************************************************************
-<a id="POST-INSTALL"/> </a>
+<div id="POST-INSTALL"/></div>
 
 ## After installing
 

--- a/README.markdown
+++ b/README.markdown
@@ -152,17 +152,17 @@ The below assumes a Model named 'User' and a Controller named 'Session'; please 
 
  * Add these familiar login URLs to your `config/routes.rb` if you like:
 
-     map.signup  '/signup', :controller => 'users',   :action => 'new'
-     map.login  '/login',  :controller => 'session', :action => 'new'
-     map.logout '/logout', :controller => 'session', :action => 'destroy'
+      map.signup  '/signup', :controller => 'users',   :action => 'new'
+      map.login  '/login',  :controller => 'session', :action => 'new'
+      map.logout '/logout', :controller => 'session', :action => 'destroy'
 
  * With `--include-activation`, also add to your `config/routes.rb`:
 
-     map.activate '/activate/:activation_code', :controller => 'users', :action => 'activate', :activation_code => nil
+       map.activate '/activate/:activation_code', :controller => 'users', :action => 'activate', :activation_code => nil
 
   and add an observer to `config/environment.rb`:
 
-     config.active_record.observers = :user_observer
+       config.active_record.observers = :user_observer
 
   Pay attention, may be this is not an issue for everybody, but if you should have problems, that the sent activation_code does match with that in the database stored, reload your user object before sending its data through email something like:
 
@@ -179,7 +179,7 @@ The below assumes a Model named 'User' and a Controller named 'Session'; please 
 
  * With `--stateful`, add an observer to config/environment.rb:
 
-     config.active_record.observers = :user_observer
+      config.active_record.observers = :user_observer
 
   and modify the users resource line to read
 

--- a/README.markdown
+++ b/README.markdown
@@ -14,7 +14,7 @@ Several features were updated in May, 2008.
  * ['Classic' (backward-compatible) version](http://github.com/technoweenie/restful-authentication/tree/classic)
  * [Experimental version](http://github.com/technoweenie/restful-authentication/tree/modular) (Much more modular, needs testing &amp; review)
 
- > IMPORTANT: if you upgrade your site, existing user account passwords will stop working unless you use --old-passwords
+ > IMPORTANT: if you upgrade your site, existing user account passwords will stop working unless you use `--old-passwords`
 
 ***************************************************************************
 
@@ -93,7 +93,7 @@ but may require changes to existing accounts
 
 ### Passwords
 
-The new password encryption (using a site key salt and stretching) will break existing user accounts' passwords.  We recommend you use the --old-passwords option or write a migration tool and submit it as a patch.  See the <#Tradeoffs> note for more information.
+The new password encryption (using a site key salt and stretching) will break existing user accounts' passwords.  We recommend you use the `--old-passwords` option or write a migration tool and submit it as a patch.  See the <#Tradeoffs> note for more information.
 
 ### Validations
 
@@ -129,42 +129,42 @@ To use the generator:
 
  * The second parameter specifies the session controller name.  This is the controller that handles the actual login/logout function on the site.  (probably: "Session").
 
- * --include-activation: Generates the code for a ActionMailer and its respective Activation Code through email.
+ * `--include-activation`: Generates the code for a ActionMailer and its respective Activation Code through email.
 
- * --stateful: Builds in support for acts_as_state_machine and generates activation code. (`--stateful` implies `--include-activation`). Based on the idea at <http://www.vaporbase.com/postings/stateful_authentication>. Passing `--skip-migration` will skip the user migration, and `--skip-routes` will skip resource generation -- both useful if you've already run this generator.  (Needs the [acts_as_state_machine plugin](http://elitists.textdriven.com/svn/plugins/acts_as_state_machine/) but new installs should probably run with `--aasm` instead.)
+ * `--stateful`: Builds in support for acts_as_state_machine and generates activation code. (`--stateful` implies `--include-activation`). Based on the idea at <http://www.vaporbase.com/postings/stateful_authentication>. Passing `--skip-migration` will skip the user migration, and `--skip-routes` will skip resource generation -- both useful if you've already run this generator.  (Needs the [acts_as_state_machine plugin](http://elitists.textdriven.com/svn/plugins/acts_as_state_machine/) but new installs should probably run with `--aasm` instead.)
 
- * --aasm: Works the same as stateful but uses the [updated aasm gem](http://github.com/rubyist/aasm/tree/master)
+ * `--aasm`: Works the same as stateful but uses the [updated aasm gem](http://github.com/rubyist/aasm/tree/master)
 
- * --rspec: Generate RSpec tests and Stories in place of standard rails tests.  This requires the [RSpec and Rspec-on-rails plugins](http://rspec.info/) (make sure you `./script/generate rspec` after installing RSpec.) The rspec and story suite are much more thorough than the rails tests, and changes are unlikely to be backported.
+ * `--rspec`: Generate RSpec tests and Stories in place of standard rails tests.  This requires the [RSpec and Rspec-on-rails plugins](http://rspec.info/) (make sure you `./script/generate rspec` after installing RSpec.) The rspec and story suite are much more thorough than the rails tests, and changes are unlikely to be backported.
 
- * --old-passwords: Use the older password scheme (see <#COMPATIBILITY>, above)
+ * `--old-passwords`: Use the older password scheme (see <#COMPATIBILITY>, above)
 
- * --skip-migration: Don't generate a migration file for this model
+ * `--skip-migration`: Don't generate a migration file for this model
 
- * --skip-routes: Don't generate a resource line in `config/routes.rb`
+ * `--skip-routes`: Don't generate a resource line in `config/routes.rb`
 
 ***************************************************************************
 <div id="POST-INSTALL"/></div>
 
 ## After installing
 
-The below assumes a Model named 'User' and a Controller named 'Session'; please alter to suit. There are additional security minutae in `notes/README-Tradeoffs` -- only the paranoid or the curious need bother, though.
+The below assumes a Model named 'User' and a Controller named 'Session'; please alter to suit. There are additional security minutiae in `notes/README-Tradeoffs` -- only the paranoid or the curious need bother, though.
 
  * Add these familiar login URLs to your `config/routes.rb` if you like:
 
-      map.signup  '/signup', :controller => 'users',   :action => 'new'
-      map.login  '/login',  :controller => 'session', :action => 'new'
-      map.logout '/logout', :controller => 'session', :action => 'destroy'
+    map.signup  '/signup', :controller => 'users',  :action => 'new'
+    map.login  '/login',  :controller => 'session', :action => 'new'
+    map.logout '/logout', :controller => 'session', :action => 'destroy'
 
  * With `--include-activation`, also add to your `config/routes.rb`:
 
-       map.activate '/activate/:activation_code', :controller => 'users', :action => 'activate', :activation_code => nil
+    map.activate '/activate/:activation_code', :controller => 'users', :action => 'activate', :activation_code => nil
 
-  and add an observer to `config/environment.rb`:
+and add an observer to `config/environment.rb`:
 
-       config.active_record.observers = :user_observer
+    config.active_record.observers = :user_observer
 
-  Pay attention, may be this is not an issue for everybody, but if you should have problems, that the sent activation_code does match with that in the database stored, reload your user object before sending its data through email something like:
+Pay attention, may be this is not an issue for everybody, but if you should have problems, that the sent activation_code does match with that in the database stored, reload your user object before sending its data through email something like:
 
      class UserObserver < ActiveRecord::Observer
        def after_create(user)
@@ -177,14 +177,14 @@ The below assumes a Model named 'User' and a Controller named 'Session'; please 
        end
      end
 
- * With `--stateful`, add an observer to config/environment.rb:
+ * With `--stateful`, add an observer to `config/environment.rb`:
 
-      config.active_record.observers = :user_observer
+    config.active_record.observers = :user_observer
 
-  and modify the users resource line to read
+and modify the users resource line to read
 
      map.resources :users, :member => { :suspend   => :put,
                                         :unsuspend => :put,
                                         :purge     => :delete }
 
-* If you use a public repository for your code (such as github, rubyforge, gitorious, etc.) make sure to NOT post your site_keys.rb (add a line like '/config/initializers/site_keys.rb' to your .gitignore or do the svn ignore dance), but make sure you DO keep it backed up somewhere safe.
+ * If you use a public repository for your code (such as github, rubyforge, gitorious, etc.) make sure to NOT post your site_keys.rb (add a line like `/config/initializers/site_keys.rb` to your `.gitignore` or do the svn ignore dance), but make sure you DO keep it backed up somewhere safe.

--- a/README.markdown
+++ b/README.markdown
@@ -1,54 +1,56 @@
-# "Restful Authentication Generator":http://github.com/technoweenie/restful-authentication
+# "Restful Authentication Generator"
 
-This widely-used plugin provides a foundation for securely managing user
-authentication:
-* Login / logout
-* Secure password handling
-* Account activation by validating email
-* Account approval / disabling by admin
-* Rudimentary hooks for authorization and access control.
+This widely-used plugin provides a foundation for securely managing user authentication:
+
+ * Login / logout
+ * Secure password handling
+ * Account activation by validating email
+ * Account approval / disabling by admin
+ * Rudimentary hooks for authorization and access control.
 
 Several features were updated in May, 2008.
-* "Stable newer version":http://github.com/technoweenie/restful-authentication/tree/master
-* "'Classic' (backward-compatible) version":http://github.com/technoweenie/restful-authentication/tree/classic
-* "Experimental version":http://github.com/technoweenie/restful-authentication/tree/modular (Much more modular, needs testing & review)
 
-> IMPORTANT: if you upgrade your site, existing user account
-> passwords will stop working unless you use --old-passwords
+ * [Stable newer version](http://github.com/technoweenie/restful-authentication/tree/master)
+ * ['Classic' (backward-compatible) version](http://github.com/technoweenie/restful-authentication/tree/classic)
+ * [Experimental version](http://github.com/technoweenie/restful-authentication/tree/modular) (Much more modular, needs testing &amp; review)
+
+ > IMPORTANT: if you upgrade your site, existing user account passwords will stop working unless you use --old-passwords
 
 ***************************************************************************
 
 ## Issue Tracker
 
 Please submit any bugs or annoyances on the lighthouse tracker at
-* "http://rails_security.lighthouseapp.com/projects/15332-restful_authentication/overview":http://rails_security.lighthouseapp.com/projects/15332-restful_authentication/overview
 
-For anything simple enough, please github message both maintainers: Rick Olson
-("technoweenie":http://github.com/technoweenie) and Flip Kromer
-("mrflip":http://github.com/mrflip).
+ * <http://rails_security.lighthouseapp.com/projects/15332-restful_authentication/overview>
+
+For anything simple enough, please github message both maintainers:
+
+ * Rick Olson ([technoweenie](http://github.com/technoweenie))
+ * Flip Kromer ([mrflip](http://github.com/mrflip)).
 
 ***************************************************************************
 
 ## Documentation
 
 This page has notes on
-* "Installation":#INSTALL
-* "New Features":#AWESOME
-* "After installing":#POST-INSTALL
 
-See the "wiki":http://github.com/technoweenie/restful-authentication/wikis/home
-(or the notes/ directory) if you want to learn more about:
+ * [Installation](#INSTALL)
+ * [New Features](#AWESOME)
+ * [After installing](#POST-INSTALL)
 
-* "Extensions, Addons and Alternatives":addons such as HAML templates
-* "Security Design Patterns":security-patterns with "snazzy diagram":http://github.com/technoweenie/restful-authentication/tree/master/notes/SecurityFramework.png
-* Authentication -- Lets a visitor identify herself (and lay  claim to her corresponding Roles and measure of Trust)
-* "Trust Metrics":Trustification -- Confidence we can rely on the outcomes of this visitor's actions.
-* Authorization and Policy -- Based on trust and identity, what actions may this visitor perform?
-* Access Control -- How the Authorization policy is actually enforced in your code (A: hopefully without turning it into  a spaghetti of if thens)
-* Rails Plugins for Authentication, Trust,  Authorization and Access Control
-* Tradeoffs -- for the paranoid or the curious, a rundown of tradeoffs made in the code
-* CHANGELOG -- Summary of changes to internals
-* TODO -- Ideas for how you can help
+See the [wiki](http://github.com/technoweenie/restful-authentication/wikis/home) (or the notes/ directory) if you want to learn more about:
+
+ * "Extensions, Addons and Alternatives":addons such as HAML templates
+ * "Security Design Patterns":security-patterns with "snazzy diagram":http://github.com/technoweenie/restful-authentication/tree/master/notes/SecurityFramework.png
+ * Authentication -- Lets a visitor identify herself (and lay  claim to her corresponding Roles and measure of Trust)
+ * "Trust Metrics":Trustification -- Confidence we can rely on the outcomes of this visitor's actions.
+ * Authorization and Policy -- Based on trust and identity, what actions may this visitor perform?
+ * Access Control -- How the Authorization policy is actually enforced in your code (A: hopefully without turning it into  a spaghetti of if thens)
+ * Rails Plugins for Authentication, Trust,  Authorization and Access Control
+ * Tradeoffs -- for the paranoid or the curious, a rundown of tradeoffs made in the code
+ * CHANGELOG -- Summary of changes to internals
+ * TODO -- Ideas for how you can help
 
 These best version of the release notes are in the notes/ directory in the
 "source code":http://github.com/technoweenie/restful-authentication/tree/master
@@ -63,23 +65,21 @@ from there.
 
 ### Stories
 
-There are now "Cucumber":http://wiki.github.com/aslakhellesoy/cucumber/home features that allow expressive, enjoyable tests for the
-authentication code. The flexible code for resource testing in stories was
-extended from "Ben Mabey's.":http://www.benmabey.com/2008/02/04/rspec-plain-text-stories-webrat-chunky-bacon/
+There are now [Cucumber](http://wiki.github.com/aslakhellesoy/cucumber/home) features that allow expressive, enjoyable tests for the authentication code. The flexible code for resource testing in stories was extended from [Ben Mabey's](http://www.benmabey.com/2008/02/04/rspec-plain-text-stories-webrat-chunky-bacon/).
 
 ### Modularize to match security design patterns:
 
-* Authentication (currently: password, browser cookie token, HTTP basic)
-* Trust metric (email validation)
-* Authorization (stateful roles)
-* Leave a flexible framework that will play nicely with other access control / policy definition / trust metric plugins
+ * Authentication (currently: password, browser cookie token, HTTP basic)
+ * Trust metric (email validation)
+ * Authorization (stateful roles)
+ * Leave a flexible framework that will play nicely with other access control / policy definition / trust metric plugins
 
 ### Other
 
-* Added a few helper methods for linking to user pages
-* Uniform handling of logout, remember_token
-* Stricter email, login field validation
-* Minor security fixes -- see CHANGELOG
+ * Added a few helper methods for linking to user pages
+ * Uniform handling of logout, remember_token
+ * Stricter email, login field validation
+ * Minor security fixes -- see CHANGELOG
 
 ***************************************************************************
 
@@ -88,17 +88,12 @@ extended from "Ben Mabey's.":http://www.benmabey.com/2008/02/04/rspec-plain-text
 Here are a few changes in the May 2008 release that increase "Defense in Depth"
 but may require changes to existing accounts
 
-* If you have an existing site, none of these changes are compelling enough to
-  warrant migrating your userbase.
-* If you are generating for a new site, all of these changes are low-impact.
-  You should apply them.
+ * If you have an existing site, none of these changes are compelling enough to warrant migrating your userbase.
+ * If you are generating for a new site, all of these changes are low-impact. You should apply them.
 
 ### Passwords
 
-The new password encryption (using a site key salt and stretching) will break
-existing user accounts' passwords.  We recommend you use the --old-passwords
-option or write a migration tool and submit it as a patch.  See the
-[[Tradeoffs]] note for more information.
+The new password encryption (using a site key salt and stretching) will break existing user accounts' passwords.  We recommend you use the --old-passwords option or write a migration tool and submit it as a patch.  See the <#Tradeoffs> note for more information.
 
 ### Validations
 
@@ -113,53 +108,40 @@ By default, email and usernames are validated against a somewhat strict pattern;
 This is a basic restful authentication generator for rails, taken from
 acts as authenticated.  Currently it requires Rails 1.2.6 or above.
 
-**IMPORTANT FOR RAILS > 2.1 USERS** To avoid a @NameError@ exception ("lighthouse tracker ticket":http://rails_security.lighthouseapp.com/projects/15332-restful_authentication/tickets/2-not-a-valid-constant-name-errors#ticket-2-2), check out the code to have an _underscore_ and not _dash_ in its name:
-* either use <code>git clone git://github.com/technoweenie/restful-authentication.git restful_authentication</code>
-* or rename the plugin's directory to be <code>restful_authentication</code> after fetching it.
+**IMPORTANT FOR RAILS > 2.1 USERS**
+
+To avoid a @NameError@ exception ([lighthouse tracker ticket](http://rails_security.lighthouseapp.com/projects/15332-restful_authentication/tickets/2-not-a-valid-constant-name-errors#ticket-2-2), check out the code to have an _underscore_ and not _dash_ in its name:
+
+ * either use `git clone git://github.com/technoweenie/restful-authentication.git restful_authentication`
+ * or rename the plugin's directory to be <code>restful_authentication</code> after fetching it.
 
 To use the generator:
 
-  ./script/generate authenticated user sessions \
-    --include-activation \
-    --stateful \
-    --rspec \
-    --skip-migration \
-    --skip-routes \
-    --old-passwords
+    ./script/generate authenticated user sessions \
+      --include-activation \
+      --stateful \
+      --rspec \
+      --skip-migration \
+      --skip-routes \
+      --old-passwords
 
-* The first parameter specifies the model that gets created in signup (typically
-  a user or account model).  A model with migration is created, as well as a
-  basic controller with the create method. You probably want to say "User" here.
+ * The first parameter specifies the model that gets created in signup (typically a user or account model).  A model with migration is created, as well as a basic controller with the create method. You probably want to say "User" here.
 
-* The second parameter specifies the session controller name.  This is the
-  controller that handles the actual login/logout function on the site.
-  (probably: "Session").
+ * The second parameter specifies the session controller name.  This is the controller that handles the actual login/logout function on the site.  (probably: "Session").
 
-* --include-activation: Generates the code for a ActionMailer and its respective
-  Activation Code through email.
+ * --include-activation: Generates the code for a ActionMailer and its respective Activation Code through email.
 
-* --stateful: Builds in support for acts_as_state_machine and generates
-  activation code.  (@--stateful@ implies @--include-activation@). Based on the
-  idea at [[http://www.vaporbase.com/postings/stateful_authentication]]. Passing
-  @--skip-migration@ will skip the user migration, and @--skip-routes@ will skip
-  resource generation -- both useful if you've already run this generator.
-  (Needs the "acts_as_state_machine plugin":http://elitists.textdriven.com/svn/plugins/acts_as_state_machine/,
-  but new installs should probably run with @--aasm@ instead.)
+ * --stateful: Builds in support for acts_as_state_machine and generates activation code.  (@--stateful@ implies @--include-activation@). Based on the idea at [[http://www.vaporbase.com/postings/stateful_authentication]]. Passing @--skip-migration@ will skip the user migration, and @--skip-routes@ will skip resource generation -- both useful if you've already run this generator.  (Needs the "acts_as_state_machine plugin":http://elitists.textdriven.com/svn/plugins/acts_as_state_machine/, but new installs should probably run with @--aasm@ instead.)
 
-* --aasm: Works the same as stateful but uses the "updated aasm gem":http://github.com/rubyist/aasm/tree/master
+ * --aasm: Works the same as stateful but uses the "updated aasm gem":http://github.com/rubyist/aasm/tree/master
 
-* --rspec: Generate RSpec tests and Stories in place of standard rails tests.
-  This requires the
-    "RSpec and Rspec-on-rails plugins":http://rspec.info/
-  (make sure you "./script/generate rspec" after installing RSpec.)  The rspec
-  and story suite are much more thorough than the rails tests, and changes are
-  unlikely to be backported.
+ * --rspec: Generate RSpec tests and Stories in place of standard rails tests.  This requires the [RSpec and Rspec-on-rails plugins](http://rspec.info/) (make sure you `./script/generate rspec` after installing RSpec.) The rspec and story suite are much more thorough than the rails tests, and changes are unlikely to be backported.
 
-* --old-passwords: Use the older password scheme (see [[#COMPATIBILITY]], above)
+ * --old-passwords: Use the older password scheme (see <#COMPATIBILITY>, above)
 
-* --skip-migration: Don't generate a migration file for this model
+ * --skip-migration: Don't generate a migration file for this model
 
-* --skip-routes: Don't generate a resource line in @config/routes.rb@
+ * --skip-routes: Don't generate a resource line in @config/routes.rb@
 
 ***************************************************************************
 <a id="POST-INSTALL"/> </a>
@@ -172,30 +154,23 @@ alter to suit. There are additional security minutae in @notes/README-Tradeoffs@
 
 * Add these familiar login URLs to your @config/routes.rb@ if you like:
 
-    <pre><code>
     map.signup  '/signup', :controller => 'users',   :action => 'new'
     map.login  '/login',  :controller => 'session', :action => 'new'
     map.logout '/logout', :controller => 'session', :action => 'destroy'
-    </code></pre>
 
 * With @--include-activation@, also add to your @config/routes.rb@:
 
-    <pre><code>
     map.activate '/activate/:activation_code', :controller => 'users', :action => 'activate', :activation_code => nil
-    </code></pre>
 
   and add an observer to @config/environment.rb@:
 
-    <pre><code>
     config.active_record.observers = :user_observer
-    </code></pre>
 
   Pay attention, may be this is not an issue for everybody, but if you should
   have problems, that the sent activation_code does match with that in the
   database stored, reload your user object before sending its data through email
   something like:
 
-    <pre><code>
     class UserObserver < ActiveRecord::Observer
       def after_create(user)
         user.reload
@@ -206,14 +181,10 @@ alter to suit. There are additional security minutae in @notes/README-Tradeoffs@
         UserMailer.deliver_activation(user) if user.recently_activated?
       end
     end
-    </code></pre>
-
 
 * With @--stateful@, add an observer to config/environment.rb:
 
-    <pre><code>
     config.active_record.observers = :user_observer
-    </code></pre>
 
   and modify the users resource line to read
 
@@ -221,7 +192,4 @@ alter to suit. There are additional security minutae in @notes/README-Tradeoffs@
                                        :unsuspend => :put,
                                        :purge     => :delete }
 
-* If you use a public repository for your code (such as github, rubyforge,
-  gitorious, etc.) make sure to NOT post your site_keys.rb (add a line like
-  '/config/initializers/site_keys.rb' to your .gitignore or do the svn ignore
-  dance), but make sure you DO keep it backed up somewhere safe.
+* If you use a public repository for your code (such as github, rubyforge, gitorious, etc.) make sure to NOT post your site_keys.rb (add a line like '/config/initializers/site_keys.rb' to your .gitignore or do the svn ignore dance), but make sure you DO keep it backed up somewhere safe.

--- a/README.markdown
+++ b/README.markdown
@@ -41,10 +41,10 @@ This page has notes on
 
 See the [wiki](http://github.com/technoweenie/restful-authentication/wikis/home) (or the notes/ directory) if you want to learn more about:
 
- * "Extensions, Addons and Alternatives":addons such as HAML templates
- * "Security Design Patterns":security-patterns with "snazzy diagram":http://github.com/technoweenie/restful-authentication/tree/master/notes/SecurityFramework.png
+ * Extensions, Addons and Alternatives - addons such as HAML templates
+ * [Security Design Patterns](http://github.com/technoweenie/restful-authentication/tree/master/notes/SecurityFramework.png) -- security-patterns with "snazzy diagrams" 
  * Authentication -- Lets a visitor identify herself (and lay  claim to her corresponding Roles and measure of Trust)
- * "Trust Metrics":Trustification -- Confidence we can rely on the outcomes of this visitor's actions.
+ * Trust Metrics -- Trustification -- Confidence we can rely on the outcomes of this visitor's actions.
  * Authorization and Policy -- Based on trust and identity, what actions may this visitor perform?
  * Access Control -- How the Authorization policy is actually enforced in your code (A: hopefully without turning it into  a spaghetti of if thens)
  * Rails Plugins for Authentication, Trust,  Authorization and Access Control
@@ -53,7 +53,7 @@ See the [wiki](http://github.com/technoweenie/restful-authentication/wikis/home)
  * TODO -- Ideas for how you can help
 
 These best version of the release notes are in the notes/ directory in the
-"source code":http://github.com/technoweenie/restful-authentication/tree/master
+[source code](http://github.com/technoweenie/restful-authentication/tree/master)
 -- look there for the latest version.  The wiki versions are taken (manually)
 from there.
 
@@ -110,7 +110,7 @@ acts as authenticated.  Currently it requires Rails 1.2.6 or above.
 
 **IMPORTANT FOR RAILS > 2.1 USERS**
 
-To avoid a @NameError@ exception ([lighthouse tracker ticket](http://rails_security.lighthouseapp.com/projects/15332-restful_authentication/tickets/2-not-a-valid-constant-name-errors#ticket-2-2), check out the code to have an _underscore_ and not _dash_ in its name:
+To avoid a `NameError` exception ([lighthouse tracker ticket](http://rails_security.lighthouseapp.com/projects/15332-restful_authentication/tickets/2-not-a-valid-constant-name-errors#ticket-2-2), check out the code to have an _underscore_ and not _dash_ in its name:
 
  * either use `git clone git://github.com/technoweenie/restful-authentication.git restful_authentication`
  * or rename the plugin's directory to be <code>restful_authentication</code> after fetching it.
@@ -131,9 +131,9 @@ To use the generator:
 
  * --include-activation: Generates the code for a ActionMailer and its respective Activation Code through email.
 
- * --stateful: Builds in support for acts_as_state_machine and generates activation code.  (@--stateful@ implies @--include-activation@). Based on the idea at [[http://www.vaporbase.com/postings/stateful_authentication]]. Passing @--skip-migration@ will skip the user migration, and @--skip-routes@ will skip resource generation -- both useful if you've already run this generator.  (Needs the "acts_as_state_machine plugin":http://elitists.textdriven.com/svn/plugins/acts_as_state_machine/, but new installs should probably run with @--aasm@ instead.)
+ * --stateful: Builds in support for acts_as_state_machine and generates activation code. (`--stateful` implies `--include-activation`). Based on the idea at <http://www.vaporbase.com/postings/stateful_authentication>. Passing `--skip-migration` will skip the user migration, and `--skip-routes` will skip resource generation -- both useful if you've already run this generator.  (Needs the [acts_as_state_machine plugin](http://elitists.textdriven.com/svn/plugins/acts_as_state_machine/) but new installs should probably run with `--aasm` instead.)
 
- * --aasm: Works the same as stateful but uses the "updated aasm gem":http://github.com/rubyist/aasm/tree/master
+ * --aasm: Works the same as stateful but uses the [updated aasm gem](http://github.com/rubyist/aasm/tree/master)
 
  * --rspec: Generate RSpec tests and Stories in place of standard rails tests.  This requires the [RSpec and Rspec-on-rails plugins](http://rspec.info/) (make sure you `./script/generate rspec` after installing RSpec.) The rspec and story suite are much more thorough than the rails tests, and changes are unlikely to be backported.
 
@@ -141,7 +141,7 @@ To use the generator:
 
  * --skip-migration: Don't generate a migration file for this model
 
- * --skip-routes: Don't generate a resource line in @config/routes.rb@
+ * --skip-routes: Don't generate a resource line in `config/routes.rb`
 
 ***************************************************************************
 <a id="POST-INSTALL"/> </a>
@@ -149,20 +149,20 @@ To use the generator:
 ## After installing
 
 The below assumes a Model named 'User' and a Controller named 'Session'; please
-alter to suit. There are additional security minutae in @notes/README-Tradeoffs@
+alter to suit. There are additional security minutae in `notes/README-Tradeoffs`
 -- only the paranoid or the curious need bother, though.
 
-* Add these familiar login URLs to your @config/routes.rb@ if you like:
+* Add these familiar login URLs to your `config/routes.rb` if you like:
 
     map.signup  '/signup', :controller => 'users',   :action => 'new'
     map.login  '/login',  :controller => 'session', :action => 'new'
     map.logout '/logout', :controller => 'session', :action => 'destroy'
 
-* With @--include-activation@, also add to your @config/routes.rb@:
+* With `--include-activation`, also add to your `config/routes.rb`:
 
     map.activate '/activate/:activation_code', :controller => 'users', :action => 'activate', :activation_code => nil
 
-  and add an observer to @config/environment.rb@:
+  and add an observer to `config/environment.rb`:
 
     config.active_record.observers = :user_observer
 
@@ -182,7 +182,7 @@ alter to suit. There are additional security minutae in @notes/README-Tradeoffs@
       end
     end
 
-* With @--stateful@, add an observer to config/environment.rb:
+* With `--stateful`, add an observer to config/environment.rb:
 
     config.active_record.observers = :user_observer
 


### PR DESCRIPTION
I'm not sure what markup language the README was written in, but it was not markdown. This made GitHub's rendering of it damn near impossible to read. I reformatted it so it's shiny and easy to read now (IMHO).
